### PR TITLE
Add Hono Tailwind price change calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+npm-debug.log*
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# ai-apps
+# 涨跌幅计算器（Tailwind + Node.js + Hono）
+
+该示例使用 [Hono](https://hono.dev/) 作为 Node.js 服务框架，并通过 Tailwind CSS CDN 构建了一个简洁的涨跌幅计算页面。
+
+## 功能特性
+
+- 🌐 使用 Hono 启动极简 Node.js Web 服务。
+- 🎨 通过 Tailwind CSS 构建响应式、暗色主题的页面样式。
+- 📈 支持输入初始价格与最新价格，计算涨跌幅和绝对变化数值。
+- 🧮 针对无效数据（例如初始价格为 0）提供友好提示。
+
+## 本地运行
+
+```bash
+npm install
+npm start
+```
+
+默认会在 `http://localhost:3000` 启动服务，打开浏览器即可使用涨跌幅计算器。
+
+## 目录结构
+
+```
+.
+├── src
+│   └── server.js    # Hono 服务入口，返回带 Tailwind 样式的页面
+├── package.json
+└── README.md
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "ai-apps",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-apps",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@hono/node-server": "^1.19.2",
+        "hono": "^4.9.7"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.2.tgz",
+      "integrity": "sha512-lndWsd9De/btN998Aiv6gkeMVV2h9Cc0AR0qwFTmxx/YFh/PbrjgoxTpHaNaRn6F4GAkPiVJwI0W0gQF4Wn8EA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.7.tgz",
+      "integrity": "sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-apps",
+  "version": "1.0.0",
+  "description": "Price change calculator web app using Hono and Tailwind CSS",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@hono/node-server": "^1.19.2",
+    "hono": "^4.9.7"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,149 @@
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+
+const app = new Hono();
+
+const page = `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>涨跌幅计算器</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-slate-950 text-slate-100">
+    <main class="max-w-3xl mx-auto px-4 py-12">
+      <section class="bg-slate-900 border border-slate-800 rounded-3xl shadow-xl shadow-slate-900/50 p-10">
+        <div class="flex flex-col gap-6">
+          <header>
+            <p class="text-sm font-medium text-emerald-400 uppercase tracking-[0.3em]">Market Tools</p>
+            <h1 class="mt-2 text-4xl font-bold tracking-tight sm:text-5xl">涨跌幅计算器</h1>
+            <p class="mt-3 text-base leading-relaxed text-slate-300">
+              输入初始价格和最新价格，快速得到价格变化数值和涨跌幅百分比。
+            </p>
+          </header>
+
+          <form id="change-form" class="grid gap-6 sm:grid-cols-2">
+            <label class="flex flex-col gap-2">
+              <span class="text-sm font-semibold text-slate-200">初始价格</span>
+              <div class="relative">
+                <span class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">¥</span>
+                <input
+                  id="startPrice"
+                  name="startPrice"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  required
+                  class="w-full rounded-2xl border border-slate-700 bg-slate-950 py-3 pl-8 pr-4 text-base text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
+                  placeholder="例如：12.35"
+                />
+              </div>
+            </label>
+
+            <label class="flex flex-col gap-2">
+              <span class="text-sm font-semibold text-slate-200">最新价格</span>
+              <div class="relative">
+                <span class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">¥</span>
+                <input
+                  id="endPrice"
+                  name="endPrice"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  required
+                  class="w-full rounded-2xl border border-slate-700 bg-slate-950 py-3 pl-8 pr-4 text-base text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/50"
+                  placeholder="例如：15.00"
+                />
+              </div>
+            </label>
+
+            <div class="sm:col-span-2 flex flex-col gap-3">
+              <button
+                type="submit"
+                class="inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-500 px-6 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+              >
+                立即计算
+                <span class="text-lg">→</span>
+              </button>
+              <p class="text-xs text-slate-500">
+                温馨提示：初始价格为 0 时无法计算涨跌幅，请确保有有效数据。
+              </p>
+            </div>
+          </form>
+
+          <div id="result" class="grid gap-4 sm:grid-cols-2" aria-live="polite">
+            <article class="rounded-2xl border border-slate-800 bg-slate-950/60 p-6">
+              <p class="text-sm text-slate-400">价格变化</p>
+              <p id="absoluteChange" class="mt-2 text-3xl font-semibold">--</p>
+              <p id="directionLabel" class="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">等待输入</p>
+            </article>
+            <article class="rounded-2xl border border-slate-800 bg-slate-950/60 p-6">
+              <p class="text-sm text-slate-400">涨跌幅</p>
+              <p id="percentageChange" class="mt-2 text-3xl font-semibold">--</p>
+              <p class="mt-1 text-xs uppercase tracking-[0.3em] text-slate-500">相对于初始价格</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById('change-form');
+      const startInput = document.getElementById('startPrice');
+      const endInput = document.getElementById('endPrice');
+      const absoluteChange = document.getElementById('absoluteChange');
+      const percentageChange = document.getElementById('percentageChange');
+      const directionLabel = document.getElementById('directionLabel');
+
+      const formatCurrency = (value, withSign = false) => {
+        return new Intl.NumberFormat('zh-CN', {
+          style: 'currency',
+          currency: 'CNY',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+          signDisplay: withSign ? 'always' : 'auto'
+        }).format(value);
+      };
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const start = parseFloat(startInput.value);
+        const end = parseFloat(endInput.value);
+
+        if (Number.isNaN(start) || Number.isNaN(end) || start <= 0) {
+          absoluteChange.textContent = '--';
+          percentageChange.textContent = '--';
+          directionLabel.textContent = '数据无效';
+          directionLabel.className = 'mt-1 text-xs uppercase tracking-[0.3em] text-rose-400';
+          return;
+        }
+
+        const difference = end - start;
+        const percent = (difference / start) * 100;
+        const formattedDifference = formatCurrency(difference, true);
+        const formattedPercent = (percent > 0 ? '+' : percent < 0 ? '-' : '') +
+          Math.abs(percent).toFixed(2) + '%';
+
+        absoluteChange.textContent = formattedDifference;
+        percentageChange.textContent = formattedPercent;
+
+        const direction = difference > 0 ? '上涨' : difference < 0 ? '下跌' : '持平';
+        const directionColor = difference > 0 ? 'text-emerald-400' : difference < 0 ? 'text-rose-400' : 'text-slate-400';
+        directionLabel.textContent = direction;
+        directionLabel.className = 'mt-1 text-xs uppercase tracking-[0.3em] ' + directionColor;
+      });
+    </script>
+  </body>
+</html>`;
+
+app.get('/', (c) => c.html(page));
+
+const port = Number.parseInt(process.env.PORT ?? '3000', 10);
+
+serve({
+  fetch: app.fetch,
+  port
+});
+
+console.log(`🚀 服务器已启动，访问 http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- initialize a Node.js project that serves a Tailwind styled price change calculator with Hono
- add client-side logic to compute absolute and percentage price movement with validations
- document project purpose and usage instructions in the README

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68c911998108832aa9a817624f4f97df